### PR TITLE
complete Quiz1

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,15 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    //added setters to be able to change title and author
+    public void setTitle(String nTitle){
+        this.title = nTitle;
+    }
+
+    public void setAuthor(String nAuthor){
+        this.author = nAuthor;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +46,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+                //author.equals(theOtherBook.author) &&
+                //title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+         return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,6 +19,15 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    //added setters to be able to change title and rating
+    public void setTitle(String nTitle) {
+        this.title = nTitle;
+    }
+
+    public void setRating(String nRating) {
+        this.rating = nRating;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +46,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+                //rating.equals(theOtherMovie.rating) &&
+                //title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+         return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -8,26 +8,32 @@ public class Problem3Test {
     public void catchTheBugInBook() {
         // quiz //Timothy Muresan
         BookFiction f = new BookFiction("t1", "au1", "g1");
-        BookFiction fc = new BookFiction(f);
-        f.setTitle("t2");
-        f.setAuthor("au2");
+        BookFiction fc = new BookFiction(f); //At this point id is the same
         assertTrue(f.equals(fc));
 
+        f.setTitle("t2");
+        f.setAuthor("au2"); //title and author of f changed, id remains same
+        assertTrue(f.equals(fc)); //The original equals method return statement fails here
+                                  //but the fix does not fail because id remains the same
+
         fc = new BookFiction("t2", "au2", "g1");
-        assertFalse(f.equals(fc));
+        assertFalse(f.equals(fc)); //passes because id is different
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
         MovieAction movie1 = new MovieAction("G", "Cars");
-        MovieAction movie2 = new MovieAction(movie1);
-        movie1.setRating("PG13");
-        movie1.setTitle("Inception");
+        MovieAction movie2 = new MovieAction(movie1); //At this point id is the same
         assertTrue(movie1.equals(movie2));
 
+        movie1.setRating("PG13");
+        movie1.setTitle("Inception"); //title and rating of movie1 changed, id remains same
+        assertTrue(movie1.equals(movie2)); //The original equals method return statement fails here
+                                           //but the fix does not fail because id remains the same
+
         movie2 = new MovieAction("PG13", "Inception");
-        assertFalse(movie1.equals(movie2));
+        assertFalse(movie1.equals(movie2)); //passes because id is different
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -6,12 +6,28 @@ import static org.junit.Assert.*;
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        // quiz //Timothy Muresan
+        BookFiction f = new BookFiction("t1", "au1", "g1");
+        BookFiction fc = new BookFiction(f);
+        f.setTitle("t2");
+        f.setAuthor("au2");
+        assertTrue(f.equals(fc));
+
+        fc = new BookFiction("t2", "au2", "g1");
+        assertFalse(f.equals(fc));
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        MovieAction movie1 = new MovieAction("G", "Cars");
+        MovieAction movie2 = new MovieAction(movie1);
+        movie1.setRating("PG13");
+        movie1.setTitle("Inception");
+        assertTrue(movie1.equals(movie2));
+
+        movie2 = new MovieAction("PG13", "Inception");
+        assertFalse(movie1.equals(movie2));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The original tests still passed because in the test the second object to be compared was created using the copy constructor for both Movie and Book class. This means not only the id is the same as the first object but the title and author for Book and the title and rating for Movie are the same as the first object too. For the Book class, the wrong return statement of the equals method was returning true only if id and author and title were the same but because the title and/or author were not changed at some point in the test, the test still passed. The same thing happened in Movie because the title and/or rating were not changed. To solve this, I added setters so I could change title and author for Book and title and rating for Movie to make the test fail. Then with the fix, only the id needs to match.